### PR TITLE
Added auto-fetching of the newest anaconda version on Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,8 @@ RUN apt-get update --fix-missing && apt-get install -y wget bzip2 ca-certificate
     git mercurial subversion
 
 RUN echo 'export PATH=/opt/conda/bin:$PATH' > /etc/profile.d/conda.sh && \
-    wget --quiet https://repo.continuum.io/archive/Anaconda3-4.3.1-Linux-x86_64.sh -O ~/anaconda.sh && \
+    ANACONDA_VERSION=`https://repo.continuum.io/archive -q -O - | grep -o "Anaconda.-.....-Linux-x86_64.sh" | sort | tail -1`
+    wget --quiet https://repo.continuum.io/archive/${ANACONDA_VERSION} -O ~/anaconda.sh && \
     /bin/bash ~/anaconda.sh -b -p /opt/conda && \
     rm ~/anaconda.sh
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ RUN apt-get update --fix-missing && apt-get install -y wget bzip2 ca-certificate
     git mercurial subversion
 
 RUN echo 'export PATH=/opt/conda/bin:$PATH' > /etc/profile.d/conda.sh && \
-    ANACONDA_VERSION=`https://repo.continuum.io/archive -q -O - | grep -o "Anaconda.-.....-Linux-x86_64.sh" | sort | tail -1`
+    ANACONDA_VERSION=`wget https://repo.continuum.io/archive -q -O - | grep -o "Anaconda.-.....-Linux-x86_64.sh" | sort | tail -1`
     wget --quiet https://repo.continuum.io/archive/${ANACONDA_VERSION} -O ~/anaconda.sh && \
     /bin/bash ~/anaconda.sh -b -p /opt/conda && \
     rm ~/anaconda.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ RUN apt-get update --fix-missing && apt-get install -y wget bzip2 ca-certificate
     git mercurial subversion
 
 RUN echo 'export PATH=/opt/conda/bin:$PATH' > /etc/profile.d/conda.sh && \
-    ANACONDA_VERSION=`wget https://repo.continuum.io/archive -q -O - | grep -o "Anaconda.-.....-Linux-x86_64.sh" | sort | tail -1`
+    ANACONDA_VERSION=`wget https://repo.continuum.io/archive -q -O - | grep -o "Anaconda.-.....-Linux-x86_64.sh" | sort | tail -1` \
     wget --quiet https://repo.continuum.io/archive/${ANACONDA_VERSION} -O ~/anaconda.sh && \
     /bin/bash ~/anaconda.sh -b -p /opt/conda && \
     rm ~/anaconda.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ RUN apt-get update --fix-missing && apt-get install -y wget bzip2 ca-certificate
     git mercurial subversion
 
 RUN echo 'export PATH=/opt/conda/bin:$PATH' > /etc/profile.d/conda.sh && \
-    ANACONDA_VERSION=`wget https://repo.continuum.io/archive -q -O - | grep -o "Anaconda.-.....-Linux-x86_64.sh" | sort | tail -1` \
+    ANACONDA_VERSION=`wget https://repo.continuum.io/archive -q -O - | grep -o "Anaconda.-.....-Linux-x86_64.sh" | sort | tail -1` && \
     wget --quiet https://repo.continuum.io/archive/${ANACONDA_VERSION} -O ~/anaconda.sh && \
     /bin/bash ~/anaconda.sh -b -p /opt/conda && \
     rm ~/anaconda.sh


### PR DESCRIPTION
You should probably double check if everything is fine. `https://repo.continuum.io/archive -q -O - | grep -o "Anaconda.-.....-Linux-x86_64.sh" | sort | tail -1` will fetch the last version of anaconda (as of right now, it returns `Anaconda3-5.0.0-Linux-x86_64.sh`)