### PR TITLE
Added a portable way of getting the `jupyter` executable in target ma…

### DIFF
--- a/launch.sh
+++ b/launch.sh
@@ -7,4 +7,4 @@ cp jupyter_notebook_config.py /home/notebooks/
 cp openebs_utils.py /home/notebooks/
 
 echo "Running Notebook"
-/opt/conda/bin/jupyter notebook --ip='*' --notebook-dir=/home --port=8888 --no-browser
+$(command -v jupyter) notebook --ip='*' --notebook-dir=/home --port=8888 --no-browser


### PR DESCRIPTION
…chine.

It's not necessary that `jupyter` will always be available system-wide (i.e., /opt/...). It's possible it's only available in a particular user space. Hence, using `command -v <command_name>`, we can get the location of the `jupyter` executable and substitute it in the required place.