### PR TITLE
One `cp` command is sufficient to copy both files.

### DIFF
--- a/launch.sh
+++ b/launch.sh
@@ -3,8 +3,7 @@
 echo "Fetching notebooks from" $GIT_REPO
 
 git clone $GIT_REPO /home/notebooks
-cp jupyter_notebook_config.py /home/notebooks/
-cp openebs_utils.py /home/notebooks/
+cp jupyter_notebook_config.py openebs_utils.py /home/notebooks/
 
 echo "Running Notebook"
 /opt/conda/bin/jupyter notebook --ip='*' --notebook-dir=/home --port=8888 --no-browser


### PR DESCRIPTION
Removed multiple `cp` commands.