### PR TITLE
Fix for allow-root issue

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,6 +23,10 @@ RUN apt-get install -y curl grep sed dpkg && \
 
 ENV PATH /opt/conda/bin:$PATH
 
+RUN python -m pip install --upgrade https://storage.googleapis.com/tensorflow/mac/cpu/tensorflow-0.12.0-py3-none-any.whl
+
+RUN pip install --upgrade keras
+
 ADD launch.sh jupyter_notebook_config.py openebs_utils.py /
 
 ENV GIT_REPO https://github.com/satyamz/ml-playground.git

--- a/launch.sh
+++ b/launch.sh
@@ -6,4 +6,4 @@ git clone $GIT_REPO /home/notebooks
 cp jupyter_notebook_config.py openebs_utils.py /home/notebooks/
 
 echo "Running Notebook"
-$(command -v jupyter) notebook --ip='*' --notebook-dir=/home --port=8888 --no-browser
+$(command -v jupyter) notebook --ip='*' --notebook-dir=/home --port=8888 --no-browser --allow-root


### PR DESCRIPTION
Added `--allow-root` flag to the `launch.sh`. This prevents the container from exiting when the Dockerfile or other contents are changed and the image is re-built.