### PR TITLE
Enables notebook to be used for deep learning

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,6 +23,10 @@ RUN apt-get install -y curl grep sed dpkg && \
 
 ENV PATH /opt/conda/bin:$PATH
 
+RUN python -m pip install --upgrade https://storage.googleapis.com/tensorflow/mac/cpu/tensorflow-0.12.0-py3-none-any.whl
+
+RUN pip install --upgrade keras
+
 ADD launch.sh jupyter_notebook_config.py openebs_utils.py /
 
 ENV GIT_REPO https://github.com/satyamz/ml-playground.git


### PR DESCRIPTION
Update in `Dockerfile` to add `keras` and `Tensorflow` libraries.
This will enable the notebook to be used for deep learning tasks as well.

Refer issue: https://github.com/openebs/easy-jupyter/issues/8